### PR TITLE
Add support for blade file type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -g emmet-ls
     configs.emmet_ls = {    
       default_config = {    
         cmd = {'emmet-ls', '--stdio'};
-        filetypes = {'html', 'css'};
+        filetypes = {'html', 'css', 'blade'};
         root_dir = function(fname)    
           return vim.loop.cwd()
         end;    

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,7 +192,7 @@ connection.onCompletion(
       let right = extractPosition.start;
       let abbreviation = extractPosition.abbreviation;
       let textResult = "";
-      if (languageId === "html") {
+      if (languageId === "html" || languageId === "blade") {
         const htmlconfig = resolveConfig({
           options: {
             "output.field": (index, placeholder) =>


### PR DESCRIPTION
Blade is a template engine of Laravel framework for PHP language.
Since the templates are written in html it is only necessary to handle them in the same way as html.
Maybe this also can be extended to support other file types.