### PR TITLE
fix: the right side should be the end not the start.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -189,7 +189,7 @@ connection.onCompletion(
       }
 
       let left = extractPosition.start;
-      let right = extractPosition.start;
+      let right = extractPosition.end;
       let abbreviation = extractPosition.abbreviation;
       let textResult = "";
       if (languageId === "html" || languageId === "blade") {


### PR DESCRIPTION
Working with `nvim-cmp` and `luasnip` notice that after triggering the expand the trigger was still at the end
for example `.class` will transform into `<div class="class"></div>.class` 

After debugging a lot, found that the problem was here the range which define all the text to be replace was not correctly.

Both left and right variables where defined as the start when the right should be defined as the end.
After fixing that can confirm locally that is solve for me.

Hope this helps others best regards.