### PR TITLE
Add Twig HTML support

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -192,7 +192,8 @@ connection.onCompletion(
       let right = extractPosition.end;
       let abbreviation = extractPosition.abbreviation;
       let textResult = "";
-      if (languageId === "html" || languageId === "blade") {
+      const htmlLanguages = ["html", "blade", "twig"];
+      if (htmlLanguages.includes(languageId)) {
         const htmlconfig = resolveConfig({
           options: {
             "output.field": (index, placeholder) =>


### PR DESCRIPTION
Add support for Twig as an HTML language. Twig is a templating language in the same vein as Blade.

Also extracted the HTML language strings into an array, so we don't need a separate check for each one. In my opinion this makes the code more readable if additional languages are added.