### PR TITLE
Add support for ERB

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -192,7 +192,7 @@ connection.onCompletion(
       let right = extractPosition.end;
       let abbreviation = extractPosition.abbreviation;
       let textResult = "";
-      const htmlLanguages = ["html", "blade", "twig"];
+      const htmlLanguages = ["html", "blade", "twig", "eruby", "erb"];
       if (htmlLanguages.includes(languageId)) {
         const htmlconfig = resolveConfig({
           options: {


### PR DESCRIPTION
Simply adding `erb` and `eruby` to the languageId list checked for `html` like languages. 