### PR TITLE
add razor .cshtml support for dotnet

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -192,7 +192,7 @@ connection.onCompletion(
       let right = extractPosition.end;
       let abbreviation = extractPosition.abbreviation;
       let textResult = "";
-      const htmlLanguages = ["html", "blade", "twig"];
+      const htmlLanguages = ["html", "blade", "twig", "razor"];
       if (htmlLanguages.includes(languageId)) {
         const htmlconfig = resolveConfig({
           options: {


### PR DESCRIPTION
Today the autocompletion generates css instead of html when using emmet-ls in a razor file (.cshtml)