### PR TITLE
Add heex support for Phoenix

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -206,6 +206,7 @@ connection.onCompletion(
         "typescript",
         "typescriptreact",
         "typescript.tsx",
+        "heex"
       ];
 
       if (htmlLanguages.includes(languageId)) {


### PR DESCRIPTION
In the Elixir community, we usually use `HEEx` as Html templates:

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/12830256/158920154-97748d53-6149-4205-9518-6acf71906337.png">
