### PR TITLE
Fix TSX, JSX support, add Sass, Less support, and add support for arbitrary markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,24 @@ npm install -g emmet-ls
 
 #### Configuration 
 
-- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
-  ```lua
-  local lspconfig = require'lspconfig'
-  local configs = require'lspconfig/configs'    
-  local capabilities = vim.lsp.protocol.make_client_capabilities()
-  capabilities.textDocument.completion.completionItem.snippetSupport = true
+##### Example Configuration
 
-  lspconfig.emmet_ls.setup({
-      -- on_attach = on_attach,
-      capabilities = capabilities,
-      filetypes = { "html", "css", "typescriptreact", "javascriptreact" },
-  })
-  ```
+With [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig):
+
+```lua
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig/configs')
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+lspconfig.emmet_ls.setup({
+    -- on_attach = on_attach,
+    capabilities = capabilities,
+    filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less' },
+})
+```
+
+##### Supported Filetypes
+
+- `html`, `typescriptreact`, `javascriptreact`, `css`, `sass`, `scss` and `less` filetypes are fully supported.
+- Any other filetype is treated as `html`.


### PR DESCRIPTION
Hi, I noticed JSX/TSX support was not working as expected. Snippets used `class` instead of `className`.

I managed to fix the issue by setting the `syntax` option in the Emmet configuration.
Along the way I added Sass, SCSS, and Less support, and refactored the defaults to work with any HTML template type.

Overview of changes made:

- Fixed abbreviations using `class` instead of `className` in JSX and TSX files.
- Added support for Sass and Less stylesheets.
- Refactored to treat unknown languages as markup with html syntax, removing the need for #33, #36 and future PRs of that kind.
- Removed unused code and generally cleaned things up.

I've tested with HTML, Jinja, JSX, TSX, CSS, Sass, SCSS and Less.
