### PR TITLE
Add className support for jsx files

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -208,9 +208,18 @@ connection.onCompletion(
         "typescript.tsx",
       ];
 
+      const jsxLanguages = [
+        "javascriptreact",
+        "typescriptreact",
+        "javascript.jsx",
+        "typescript.tsx",
+      ];
+
       if (htmlLanguages.includes(languageId)) {
+        const enableJsx = jsxLanguages.includes(languageId);
         const htmlconfig = resolveConfig({
           options: {
+            "jsx.enabled": enableJsx,
             "output.field": (index, placeholder) =>
               `\$\{${index}${placeholder ? ":" + placeholder : ""}\}`,
           },


### PR DESCRIPTION
Closes #34 

--- 

## How to run this before it gets merged

1. Clone my fork of emmet-ls: https://github.com/filipekiss/emmet-ls
2. Install dependencies with `npm install`
3. Build the project with `npm run build`
4. Link the forked version using `npm link`
5. Go to the `emmet-ls` folder. If you're using [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer), that will be `$HOME/.local/share/nvim/lsp_servers/emmet_ls`
6. Run `npm link emmet-ls`.
7. Check that the correct version is being used: `cat node_modules/.bin/emmet-ls | grep "enableJsx"`. You should see something similar to:
```sh
 const enableJsx = jsxLanguages.includes(languageId);
                    "jsx.enabled": enableJsx,
```
8. Restart Neovim and the new server should be used