### PR TITLE
add custom `emmet/parseMarkup` handler

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -235,6 +235,17 @@ connection.onCompletion(
     }
 );
 
+connection.onRequest("emmet/parseMarkup", (params) => {
+  if (params?.text == null) {
+    return { errno: 1, message: "Text param not found" };
+  }
+  const parsed = parseMarkup(params.text, {
+    options: { inlineElements: [] },
+    snippets: {},
+  } as unknown as any);
+  return { data: parsed, errno: 0 };
+});
+
 documents.listen(connection);
 
 connection.listen();


### PR DESCRIPTION
*why?*
Exposes some APIs to be used by the frontend to enable the user to customize certain behaviors, for example, filtering out the completion result if the starting node is parsed as a `div`