### PR TITLE
Set resolveProvider capability to false

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -105,7 +105,7 @@ connection.onInitialize((params: InitializeParams) => {
             textDocumentSync: TextDocumentSyncKind.Incremental,
             // Tell the client that this server supports code completion.
             completionProvider: {
-                resolveProvider: true,
+                resolveProvider: false,
                 triggerCharacters: triggerCharacters,
             },
         },


### PR DESCRIPTION
It's my understanding that the `resolveProvider: true` property in the `completionProvider` capability in the Language Server Protocol (LSP) signals that the language server can resolve extra details for a completion item. A language server that specifies `resolveProvider: true` should typically implement a `completionItem/resolve` handler, which the client will call to resolve a completion item returned from the `textDocument/completion` request.

The client I'm using, [helix](https://github.com/helix-editor/helix), checks the `completionProvider` capbility, sees `true`, and calls `completionItem/resolve`. Since the `emmet-ls` connection doesn't implement `onCompletionResolve`, this causes a "method unhandled" error.

The comment in `server.ts` suggests that `resolveProvider` may have been set to `true` with the assumption that it simply enables completion. It should be `false` unless `emmet-ls` chooses to implement `completionItem/resolve`.